### PR TITLE
Add October 2025 arXiv preprints to preprints section

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,6 +797,26 @@
         </li>
         <li class="card pub">
           <div>
+            <div class="pub-title"><a href="https://arxiv.org/abs/2510.09988" target="_blank" rel="noopener">Unifying Tree Search Algorithm and Reward Design for LLM Reasoning: A Survey</a></div>
+            <div class="authors">J. Wei, X. Zhang, Y. Yang, W. Huang, J. Cao, <strong>S. Xu</strong>, X. Zhuang, Z. Gao, M. Abdul-Mageed, L. V. S. Lakshmanan, C. You, W. Ouyang, S. Sun</div>
+            <div class="pub-venue">arXiv, 2025</div>
+          </div>
+          <div class="pub-actions">
+            <a class="btn" href="https://arxiv.org/abs/2510.09988" target="_blank" rel="noopener">Paper</a>
+          </div>
+        </li>
+        <li class="card pub">
+          <div>
+            <div class="pub-title"><a href="https://arxiv.org/abs/2510.08169" target="_blank" rel="noopener">Bidirectional Representations Augmented Autoregressive Biological Sequence Generation: Application in De Novo Peptide Sequencing</a></div>
+            <div class="authors">X. Zhang, J. Wei, Z. Qiu, <strong>S. Xu</strong>, Z. Jin, Z. Gao, N. Dong, S. Sun</div>
+            <div class="pub-venue">arXiv, 2025</div>
+          </div>
+          <div class="pub-actions">
+            <a class="btn" href="https://arxiv.org/abs/2510.08169" target="_blank" rel="noopener">Paper</a>
+          </div>
+        </li>
+        <li class="card pub">
+          <div>
             <div class="pub-title"><a href="https://arxiv.org/abs/2508.02137" target="_blank" rel="noopener">Fitness aligned structural modeling enables scalable virtual screening with AuroBind</a></div>
             <div class="authors">Z. Zhang, J. Rao, J. Zhong, W. Bai, D. Wang, S. Ning, L. Qiao, <strong>S. Xu</strong>, et al.</div>
             <div class="pub-venue">arXiv, 2025</div>


### PR DESCRIPTION
## Summary
- add the October 2025 arXiv survey on tree search and reward design for LLM reasoning to the preprints list
- include the October 2025 arXiv work on bidirectional-augmented autoregressive sequence generation in the preprints list

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6904e37179308327a6e94eea7bf934c7