### PR TITLE
Update FoldBench news date to December 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,7 +479,7 @@
       <div class="card">
         <div class="timeline">
           <div class="tl-item">
-            <span class="period">May 2025</span> — <em>FoldBench</em> published in <em>Nature Communications</em>, presenting the first all-atom benchmark for structure prediction methods.
+            <span class="period">Dec 2025</span> — <em>FoldBench</em> published in <em>Nature Communications</em>, presenting the first all-atom benchmark for structure prediction methods.
           </div>
           <div class="tl-item">
             <span class="period">May 2025</span> — <em>CRAFTS</em> published in <em>Science</em>. 🎉
@@ -886,7 +886,7 @@
 
     <footer>
       <div class="container">
-        <div>© <span id="year"></span> Sheng Xu • Last updated <span id="updated">September 2025</span></div>
+        <div>© <span id="year"></span> Sheng Xu • Last updated <span id="updated">December 2025</span></div>
       </div>
     </footer>
   </main>


### PR DESCRIPTION
## Summary
- correct the FoldBench news timeline entry to use December 2025
- update the footer's last-updated timestamp to December 2025 for consistency

## Testing
- not run (not needed for static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694367708b208327a0ad20d27ce42d26)