### PR TITLE
Update FoldBench publication year to 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,7 +430,7 @@
             <div>
               <a class="pub-title-link" href="https://www.nature.com/articles/s41467-025-67127-3" target="_blank" rel="noopener">Benchmarking all-atom biomolecular structure prediction with FoldBench</a>
               <div class="pub-authors"><strong>S. Xu*</strong>, Q. Feng*, L. Qiao, H. Wu, T. Shen, Y. Cheng, S. Zheng, S. Sun</div>
-              <span class="pub-venue">Nature Communications, 2026</span>
+              <span class="pub-venue">Nature Communications, 2025</span>
             </div>
             <div class="pub-btns">
               <a class="pub-btn" href="https://www.nature.com/articles/s41467-025-67127-3" target="_blank" rel="noopener">Paper</a>


### PR DESCRIPTION
### Motivation
- Fix the displayed publication year for the FoldBench entry which was incorrectly `Nature Communications, 2026`.

### Description
- Replace `Nature Communications, 2026` with `Nature Communications, 2025` in `index.html` for the FoldBench publication entry.

### Testing
- Verified the change with `rg -n "Foldbench|FoldBench|foldbench|发表时间|2025"`, inspected the modification with `git diff -- index.html`, and checked the working tree with `git status --short`, and all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9eaa9c6c83279b810730f8fb4e7e)