### PR TITLE
Update affiliation and add advisor links on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,8 @@
     .exp-entry { margin-bottom: 1.5rem; }
     .exp-entry .org { font-weight: 500; color: var(--text); font-size: 0.95rem; }
     .exp-entry .meta { font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.15rem; }
+    .exp-entry .submeta { font-size: 0.82rem; color: var(--text-secondary); margin-top: 0.12rem; }
+    .exp-entry .submeta a { font-weight: 500; }
 
     /* ── PUBLICATIONS ── */
     .pub-list { list-style: none; }
@@ -327,7 +329,7 @@
             <h1>Sheng Xu <span class="zh-name">许晟</span></h1>
             <dl class="info-list">
               <div class="info-row"><dt>Position</dt><dd>PhD Student, Biomedical Engineering</dd></div>
-              <div class="info-row"><dt>Affiliation</dt><dd>Fudan University</dd></div>
+              <div class="info-row"><dt>Affiliation</dt><dd><a href="https://beamlab.ai/" target="_blank" rel="noopener">BEAM Lab</a>, Fudan University &amp; Shanghai Artificial Intelligence Laboratory</dd></div>
               <!-- <div class="info-row"><dt>Intern</dt><dd>Shanghai AI Laboratory</dd></div> -->
               <div class="info-row"><dt>Research</dt><dd>AI for Molecular Biology · Computational Virology · Protein & Genome Language Models</dd></div>
             </dl>
@@ -396,10 +398,12 @@
             <div class="exp-entry">
               <div class="org">Fudan University</div>
               <div class="meta">PhD in Biomedical Engineering · 2023 – present</div>
+              <div class="submeta">Advisor: <a href="https://intersun.github.io/" target="_blank" rel="noopener">Prof. Siqi Sun</a></div>
             </div>
             <div class="exp-entry">
               <div class="org">The Chinese University of Hong Kong</div>
               <div class="meta">MSc in Computer Science · 2021 – 2022</div>
+              <div class="submeta">Advisor: <a href="https://liyu95.com/" target="_blank" rel="noopener">Prof. Yu Li</a></div>
             </div>
             <div class="exp-entry">
               <div class="org">East China Normal University</div>


### PR DESCRIPTION
### Motivation
- Update the homepage contact/education information to show the lab affiliation (with link) and record advisors for current/past degrees while preserving the page's visual hierarchy.

### Description
- Replace the hero `Affiliation` line with a linked `BEAM Lab` plus `Fudan University & Shanghai Artificial Intelligence Laboratory` in `index.html`.
- Add `Advisor` lines under the `Fudan University` and `The Chinese University of Hong Kong` education entries linking to `https://intersun.github.io/` and `https://liyu95.com/` respectively.
- Introduce lightweight `.exp-entry .submeta` and `.exp-entry .submeta a` CSS rules to match the existing typography and spacing.

### Testing
- Ran `git status --short` to verify changes and `git add`/`git commit -m "Update affiliation and add advisor links in education"` to record the update, both succeeded.
- Inspected the modified regions with `nl -ba index.html | sed -n '208,220p;326,334p;394,408p'` to confirm the new markup and styles were inserted correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cea430388327aeb0ad331de50dd0)