### PR TITLE
Add Google Analytics (gtag) snippet to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,15 @@
   <meta property="og:title" content="Sheng Xu | Fudan University" />
   <meta property="og:description" content="Sheng Xu is a PhD student at Fudan University. His research interests include AI for molecular biology, computational virology, and language models." />
   <meta property="og:type" content="website" />
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YMSZ38CYNZ"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-YMSZ38CYNZ');
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500&family=Google+Sans+Display:wght@400;500;700&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,400&display=swap" rel="stylesheet">


### PR DESCRIPTION
### Motivation
- Add Google Analytics (GA4) tracking to the site using the provided Measurement ID `G-YMSZ38CYNZ`.
- Load analytics early in the page `<head>` to improve capture of pageviews and initial events.

### Description
- Added the GA4 `gtag.js` script include (`https://www.googletagmanager.com/gtag/js?id=G-YMSZ38CYNZ`) to `index.html` `<head>`.
- Initialized `window.dataLayer`, defined `gtag`, called `gtag('js', new Date())`, and set `gtag('config', 'G-YMSZ38CYNZ')`.
- No other markup or styling changes were made to the page.

### Testing
- Verified the snippet appears at the top of the `<head>` in `index.html` using a file diff check.
- Confirmed the file contains the `G-YMSZ38CYNZ` ID and the `gtag` initialization lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9c84877c83279d8ffad562c19206)