### PR TITLE
Add ViraClass preprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,6 +584,15 @@
 
           <li class="pub-item">
             <div>
+              <a class="pub-title-link" href="https://arxiv.org/abs/2606.07301" target="_blank" rel="noopener">Structure-guided taxonomic placement of divergent RNA viruses with ViraClass</a>
+              <div class="pub-authors"><strong>S. Xu</strong>, W. Huang, S. Yue, W. Bai, S. Feng, X. He, B. Zhang, Q. Feng, E. C. Holmes, W. Shi, S. Sun</div>
+              <span class="pub-venue">arXiv, 2026</span>
+            </div>
+            <div class="pub-btns"><a class="pub-btn" href="https://arxiv.org/abs/2606.07301" target="_blank" rel="noopener">Paper</a></div>
+          </li>
+
+          <li class="pub-item">
+            <div>
               <a class="pub-title-link" href="https://arxiv.org/abs/2604.02842" target="_blank" rel="noopener">ViraHinter: a dual-modal artificial intelligence framework for predicting virus-host interactions</a>
               <div class="pub-authors">W. Bai*, F. Wang*, J. Wang*, <strong>S. Xu*</strong>, et al.</div>
               <span class="pub-venue">arXiv, 2026</span>


### PR DESCRIPTION
### Motivation
- Publish a new preprint entry on the personal website so the Preprints section includes `arXiv:2606.07301` (ViraClass) with full metadata and a link to the paper.

### Description
- Inserted a new `<li class="pub-item">` in `index.html` linking to `https://arxiv.org/abs/2606.07301` with the paper title, author list, `arXiv, 2026` venue label, and a "Paper" button.

### Testing
- Ran a quick HTML parse with `python` and `HTMLParser` which completed successfully; `git diff --check` reported no issues; served the site locally and verified with `curl -I http://localhost:8000/`; captured a full-page screenshot using `npx -y playwright ... screenshot` — all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a21b529d48327b085700edc0937f7)