### PR TITLE
Restore mobile hero spacing and fix info overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
     .info-row dt {
       color: var(--text-secondary); min-width: 80px; flex-shrink: 0; font-weight: 500;
     }
-    .info-row dd { color: var(--text); margin: 0; }
+    .info-row dd { color: var(--text); margin: 0; min-width: 0; }
     .hero .links {
       display: flex; gap: 0.75rem; margin-top: 1.75rem; flex-wrap: wrap;
     }
@@ -288,13 +288,13 @@
       .nav-links { gap: 0; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
       .nav-links::-webkit-scrollbar { display: none; }
       .nav-links a { font-size: 0.78rem; padding: 0.35rem 0.45rem; white-space: nowrap; }
-      .hero { padding: 1.25rem 0 2rem; }
+      .hero { padding: 2.5rem 0 2rem; }
       .hero-grid {
         grid-template-columns: 1fr;
         gap: 1.25rem;
         text-align: center;
       }
-      .avatar-wrap { width: 128px; height: 128px; margin: 0 auto 0.25rem; order: -1; }
+      .avatar-wrap { width: 100px; height: 100px; margin: 0 auto 0.75rem; order: -1; }
       .hero .links { justify-content: center; }
       .info-row { flex-direction: column; gap: 0; text-align: left; }
       .info-row dt { min-width: unset; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--accent); }


### PR DESCRIPTION
### Motivation
- A recent style change made the mobile hero feel cramped by reducing the top padding and increasing the avatar size, and a longer affiliation line can now push/overflow the flex layout.
- Restore a more restrained mobile layout and ensure hero info text cannot force overflow in narrow viewports.

### Description
- Add `min-width: 0` to `.info-row dd` to prevent flex children from forcing overflow in narrow containers.
- Restore mobile hero top padding by setting `.hero { padding: 2.5rem 0 2rem; }` under `@media (max-width: 768px)`. 
- Reduce the mobile avatar size and adjust spacing by setting `.avatar-wrap { width: 100px; height: 100px; margin: 0 auto 0.75rem; }` under the same media query.

### Testing
- Ran a quick HTML parse using `python3` and `HTMLParser`, which succeeded.
- Ran `git diff --check` / repository checks, which reported no style errors on the modified file.
- Attempted an automated mobile screenshot with Playwright, but Chromium could not start in the environment due to a missing shared library (`libatk-1.0.so.0`), so visual screenshot verification failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de8e9cb84832789a4cba308c61054)